### PR TITLE
Remove context notifications when unwind is executed.

### DIFF
--- a/lib/chef/rewind.rb
+++ b/lib/chef/rewind.rb
@@ -41,6 +41,8 @@ class Chef
     # resource<String>:: String identifier for resource
     def unwind(resource_id)
       run_context.resource_collection.delete_resource resource_id
+      run_context.immediate_notification_collection.delete resource_id
+      run_context.delayed_notification_collection.delete resource_id
     end
   end
 end

--- a/spec/unwind_recipe_spec.rb
+++ b/spec/unwind_recipe_spec.rb
@@ -66,6 +66,29 @@ describe Chef::Recipe do
       expect { @runner.converge }.to raise_error(Chef::Provider::Cat::CatError)
     end
 
+    it "should delete notifications from run_context" do
+      # define a resource with notifications
+      @recipe.zen_master "foobar" do
+        peace false
+        action :nothing
+        notifies :blowup, "cat[blanket1]", :immediately
+        notifies :blowup, "cat[blanket2]", :delayed
+      end
+      @recipe.cat "blanket1"
+      @recipe.cat "blanket2"
+
+      # remove the previous resource and all of its notifications
+      @recipe.unwind "zen_master[foobar]"
+
+      # define a new resource with the same name as the previous but with no notifications
+      @recipe.zen_master "foobar" do
+        peace true
+        action :change
+      end
+
+      expect { @runner.converge }.to_not raise_error(Chef::Provider::Cat::CatError)
+    end
+
     it "should throw an error when unwinding a nonexistent resource" do
       expect {
         @recipe.unwind "zen_master[foobar]"


### PR DESCRIPTION
This commit removes delayed and immediate notifications from `run_context` when `unwind` is executed.

This pull request fixes #4.